### PR TITLE
feat: show item details in claim dialog

### DIFF
--- a/src/PublicWishlist/components/ClaimItemDialog.tsx
+++ b/src/PublicWishlist/components/ClaimItemDialog.tsx
@@ -5,7 +5,8 @@ import {
   SheetDialogHeader,
   SheetDialogBody,
 } from '@/components/ui/sheet-dialog';
-import { Loader2, X, Check, Gift } from 'lucide-react';
+import { Loader2, X, Check, Gift, ExternalLink, Star } from 'lucide-react';
+import { WishlistItem, Wishlist } from '../types';
 
 interface ClaimItemDialogProps {
   isOpen: boolean;
@@ -14,11 +15,19 @@ interface ClaimItemDialogProps {
   onBuyerNameChange: (name: string) => void;
   onSubmit: (e: React.FormEvent) => void;
   claiming: boolean;
+  item: WishlistItem | null;
+  wishlist: Wishlist | null;
 }
 
 interface FormContentProps extends ClaimItemDialogProps {
   t: ReturnType<typeof useTranslation>['t'];
 }
+
+const priorityKey = (priority: number) => {
+  if (priority === 3) return 'priority.high';
+  if (priority === 2) return 'priority.medium';
+  return 'priority.low';
+};
 
 const FormContent = ({
   onClose,
@@ -26,6 +35,8 @@ const FormContent = ({
   onBuyerNameChange,
   onSubmit,
   claiming,
+  item,
+  wishlist,
   t,
 }: FormContentProps) => (
   <form onSubmit={onSubmit}>
@@ -45,22 +56,77 @@ const FormContent = ({
     />
 
     <SheetDialogBody>
-      {/* Icon Placeholder */}
-      <div className="flex flex-col items-center">
-        <div className="w-48 h-48 relative">
-          <div className="absolute inset-0 bg-ios-blue/10 rounded-full blur-3xl" />
-          <div className="relative w-full h-full flex items-center justify-center">
-            <div className="relative">
-              <Gift className="w-24 h-24 text-ios-blue opacity-20 absolute -top-4 -left-4" />
-              <Gift className="w-24 h-24 text-ios-blue opacity-40 absolute top-4 left-4" />
-              <Gift className="w-32 h-32 text-ios-blue relative z-10" />
+      {/* Item Details */}
+      {item && (
+        <div className="space-y-3">
+          {/* Image */}
+          {item.url ? (
+            <div className="w-full h-48 rounded-[20px] overflow-hidden bg-ios-background/50">
+              <img
+                src={item.url}
+                alt={item.title}
+                className="w-full h-full object-cover"
+              />
             </div>
-          </div>
+          ) : (
+            <div className="flex justify-center">
+              <div className="w-32 h-32 relative">
+                <div className="absolute inset-0 bg-ios-blue/10 rounded-full blur-3xl" />
+                <div className="relative w-full h-full flex items-center justify-center">
+                  <div className="relative">
+                    <Gift className="w-14 h-14 text-ios-blue opacity-20 absolute -top-2 -left-2" />
+                    <Gift className="w-14 h-14 text-ios-blue opacity-40 absolute top-2 left-2" />
+                    <Gift className="w-20 h-20 text-ios-blue relative z-10" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Title */}
+          <h2 className="text-[22px] font-bold text-foreground tracking-tight leading-tight">
+            {item.title}
+          </h2>
+
+          {/* Description */}
+          {item.description && (
+            <p className="text-[15px] text-ios-gray leading-relaxed">
+              {item.description}
+            </p>
+          )}
+
+          {/* Price + Priority row */}
+          {((wishlist?.enable_price && item.price_range) ||
+            (wishlist?.enable_priority && item.priority > 1)) && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {wishlist?.enable_price && item.price_range && (
+                <span className="bg-ios-background/50 border border-ios-separator/10 rounded-full px-3 py-1 text-[13px] font-semibold text-foreground">
+                  {item.price_range}
+                </span>
+              )}
+              {wishlist?.enable_priority && item.priority > 1 && (
+                <span className="flex items-center gap-1 bg-ios-background/50 border border-ios-separator/10 rounded-full px-3 py-1 text-[13px] font-semibold text-yellow-500">
+                  <Star className="w-3 h-3 fill-current" />
+                  {t(priorityKey(item.priority))}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Link */}
+          {wishlist?.enable_links && item.link && (
+            <a
+              href={item.link.startsWith('http') ? item.link : `https://${item.link}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-ios-blue text-[15px] font-medium active:opacity-60 transition-opacity w-fit"
+            >
+              <ExternalLink className="w-4 h-4" />
+              {t('publicWishlist.viewItem')}
+            </a>
+          )}
         </div>
-        <p className="text-center text-[15px] text-ios-gray max-w-[260px] mt-4">
-          {t('publicWishlist.claimDescription')}
-        </p>
-      </div>
+      )}
 
       {/* Name Input */}
       <div className="space-y-6">
@@ -82,7 +148,6 @@ const FormContent = ({
 export const ClaimItemDialog = (props: ClaimItemDialogProps) => {
   const { t } = useTranslation();
 
-  // Handle the different prop naming (isOpen vs open)
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       props.onClose();

--- a/src/PublicWishlist/components/ClaimItemDialog.tsx
+++ b/src/PublicWishlist/components/ClaimItemDialog.tsx
@@ -5,7 +5,7 @@ import {
   SheetDialogHeader,
   SheetDialogBody,
 } from '@/components/ui/sheet-dialog';
-import { Loader2, X, Check, Gift, ExternalLink, Star } from 'lucide-react';
+import { Loader2, X, Gift, ExternalLink, Star } from 'lucide-react';
 import { WishlistItem, Wishlist } from '../types';
 
 interface ClaimItemDialogProps {
@@ -43,16 +43,8 @@ const FormContent = ({
     <SheetDialogHeader
       title={t('publicWishlist.claimItem')}
       onClose={onClose}
-      submitDisabled={claiming || !buyerName.trim()}
-      loading={claiming}
+      showSubmit={false}
       closeIcon={<X className="w-5 h-5" />}
-      submitIcon={
-        claiming ? (
-          <Loader2 className="w-5 h-5 animate-spin" />
-        ) : (
-          <Check className="w-5 h-5" />
-        )
-      }
     />
 
     <SheetDialogBody>
@@ -128,8 +120,8 @@ const FormContent = ({
         </div>
       )}
 
-      {/* Name Input */}
-      <div className="space-y-6">
+      {/* Name Input + Claim Button */}
+      <div className="space-y-3">
         <div className="bg-ios-background/50 rounded-[20px] px-5 py-4 border border-ios-separator/5">
           <input
             placeholder={t('publicWishlist.yourNameRequired')}
@@ -140,6 +132,19 @@ const FormContent = ({
             required
           />
         </div>
+        <button
+          type="submit"
+          disabled={claiming || !buyerName.trim()}
+          className="w-full bg-ios-blue rounded-[20px] px-5 py-4 text-[17px] font-semibold text-white disabled:opacity-40 active:opacity-80 transition-opacity flex items-center justify-center gap-2">
+          {claiming ? (
+            <>
+              <Loader2 className="w-5 h-5 animate-spin" />
+              {t('publicWishlist.claiming')}
+            </>
+          ) : (
+            t('publicWishlist.claimButton')
+          )}
+        </button>
       </div>
     </SheetDialogBody>
   </form>

--- a/src/PublicWishlist/components/ClaimItemDialog.tsx
+++ b/src/PublicWishlist/components/ClaimItemDialog.tsx
@@ -108,11 +108,14 @@ const FormContent = ({
           {/* Link */}
           {wishlist?.enable_links && item.link && (
             <a
-              href={item.link.startsWith('http') ? item.link : `https://${item.link}`}
+              href={
+                item.link.startsWith('http')
+                  ? item.link
+                  : `https://${item.link}`
+              }
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 text-ios-blue text-[15px] font-medium active:opacity-60 transition-opacity w-fit"
-            >
+              className="flex items-center gap-2 text-ios-blue text-[15px] font-medium active:opacity-60 transition-opacity w-fit">
               <ExternalLink className="w-4 h-4" />
               {t('publicWishlist.viewItem')}
             </a>
@@ -122,6 +125,9 @@ const FormContent = ({
 
       {/* Name Input + Claim Button */}
       <div className="space-y-3">
+        <p className="text-[13px] text-ios-gray px-1 opacity-50">
+          {t('publicWishlist.claimDescription')}
+        </p>
         <div className="bg-ios-background/50 rounded-[20px] px-5 py-4 border border-ios-separator/5">
           <input
             placeholder={t('publicWishlist.yourNameRequired')}

--- a/src/PublicWishlist/index.tsx
+++ b/src/PublicWishlist/index.tsx
@@ -22,6 +22,7 @@ const PublicWishlist = () => {
     items,
     loading,
     shareLink,
+    selectedItem,
     dialogOpen,
     buyerName,
     claiming,
@@ -31,6 +32,8 @@ const PublicWishlist = () => {
     closeClaimDialog,
     setBuyerName,
   } = usePublicWishlist(token);
+
+  const selectedItemData = items.find((i) => i.id === selectedItem) ?? null;
 
   useEffect(() => {
     loadWishlistByToken();
@@ -129,6 +132,8 @@ const PublicWishlist = () => {
           onBuyerNameChange={setBuyerName}
           onSubmit={handleClaimSubmit}
           claiming={claiming}
+          item={selectedItemData}
+          wishlist={wishlist}
         />
       </main>
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -133,6 +133,7 @@
     "invalidOrExpiredLink": "Invalid or expired share link",
     "linkExpired": "This share link has expired",
     "failedToLoad": "Failed to load wishlist",
+    "viewItem": "View item",
     "howItWorks": "How It Works",
     "howItWorksStep1": "Tap or click on any item card you want to buy as a gift. This reserves the item so others won't choose the same thing.",
     "howItWorksStep2": "Your name will be shown to the wishlist administrator so they know who's getting what gift, but it stays hidden from other visitors.",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -133,6 +133,7 @@
     "invalidOrExpiredLink": "Ogiltig eller utgången delningslänk",
     "linkExpired": "Denna delningslänk har gått ut",
     "failedToLoad": "Misslyckades att ladda önskelista",
+    "viewItem": "Visa föremål",
     "howItWorks": "Så Fungerar Det",
     "howItWorksStep1": "Tryck eller klicka på ett föremål du vill köpa som present. Detta reserverar föremålet så att andra inte väljer samma sak.",
     "howItWorksStep2": "Ditt namn visas för önskelistans administratör så de vet vem som ska ge vilken present, men det förblir dolt för andra besökare.",


### PR DESCRIPTION
## Summary
- Expanded the existing claim dialog to show full item details above the name input
- Replaces the decorative gift-icon placeholder with: item image (gift-icon fallback if none), title, description, price range badge, priority badge, and an external link button
- All detail fields are gated by the wishlist's feature flags (`enable_price`, `enable_priority`, `enable_links`)

## Changes
- `src/PublicWishlist/components/ClaimItemDialog.tsx` — accepts `item` and `wishlist` props; renders item details section above name input
- `src/PublicWishlist/index.tsx` — derives selected item object and passes it + wishlist to `ClaimItemDialog`
- `src/locales/en.json` + `sv.json` — adds `publicWishlist.viewItem` translation key

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)